### PR TITLE
LogRecordConfigureSelector类路径通过class 获取

### DIFF
--- a/bizlog-sdk/src/main/java/com/mzt/logapi/starter/support/LogRecordConfigureSelector.java
+++ b/bizlog-sdk/src/main/java/com/mzt/logapi/starter/support/LogRecordConfigureSelector.java
@@ -13,9 +13,6 @@ import org.springframework.lang.Nullable;
  * @author mzt.
  */
 public class LogRecordConfigureSelector extends AdviceModeImportSelector<EnableLogRecord> {
-    private static final String ASYNC_EXECUTION_ASPECT_CONFIGURATION_CLASS_NAME =
-            "com.mzt.logapi.starter.configuration.LogRecordProxyAutoConfiguration";
-
 
     @Override
     @Nullable
@@ -24,7 +21,7 @@ public class LogRecordConfigureSelector extends AdviceModeImportSelector<EnableL
             case PROXY:
                 return new String[]{AutoProxyRegistrar.class.getName(), LogRecordProxyAutoConfiguration.class.getName()};
             case ASPECTJ:
-                return new String[]{ASYNC_EXECUTION_ASPECT_CONFIGURATION_CLASS_NAME};
+                return new String[]{LogRecordProxyAutoConfiguration.class.getName()};
             default:
                 return null;
         }


### PR DESCRIPTION
类路径可以不通过常量，可以通过类路径获取，避免后续类路径改变