### PR TITLE
Add list attribute to @LogRecord annotation

### DIFF
--- a/bizlog-sdk/src/main/java/com/mzt/logapi/beans/LogRecordOps.java
+++ b/bizlog-sdk/src/main/java/com/mzt/logapi/beans/LogRecordOps.java
@@ -2,6 +2,7 @@ package com.mzt.logapi.beans;
 
 import lombok.Builder;
 import lombok.Data;
+import java.util.List;
 
 /**
  * @author muzhantong
@@ -19,4 +20,5 @@ public class LogRecordOps {
     private String extra;
     private String condition;
     private String isSuccess;
+    private List<String> list;
 }

--- a/bizlog-sdk/src/main/java/com/mzt/logapi/service/impl/DefaultLogRecordServiceImpl.java
+++ b/bizlog-sdk/src/main/java/com/mzt/logapi/service/impl/DefaultLogRecordServiceImpl.java
@@ -25,6 +25,12 @@ public class DefaultLogRecordServiceImpl implements ILogRecordService {
 //        logRecordMapper.insertSelective(logRecord);
     }
 
+    public void record(List<LogRecord> logRecords) {
+        for (LogRecord logRecord : logRecords) {
+            record(logRecord);
+        }
+    }
+
     @Override
     public List<LogRecord> queryLog(String bizNo, String type) {
         return new ArrayList<>();

--- a/bizlog-sdk/src/main/java/com/mzt/logapi/starter/annotation/LogRecord.java
+++ b/bizlog-sdk/src/main/java/com/mzt/logapi/starter/annotation/LogRecord.java
@@ -58,4 +58,9 @@ public @interface LogRecord {
      * @return 表示成功的表达式，默认为空，代表不抛异常为成功
      */
     String successCondition() default "";
+
+    /**
+     * @return list变量的名称
+     */
+    String list() default "";
 }

--- a/bizlog-sdk/src/main/java/com/mzt/logapi/starter/support/aop/LogRecordInterceptor.java
+++ b/bizlog-sdk/src/main/java/com/mzt/logapi/starter/support/aop/LogRecordInterceptor.java
@@ -196,20 +196,37 @@ public class LogRecordInterceptor extends LogRecordValueParser implements Method
                 (!diffSameWhetherSaveLog && action.contains("#") && Objects.equals(action, expressionValues.get(action)))) {
             return;
         }
-        LogRecord logRecord = LogRecord.builder()
-                .tenant(tenantId)
-                .type(expressionValues.get(operation.getType()))
-                .bizNo(expressionValues.get(operation.getBizNo()))
-                .operator(getRealOperatorId(operation, operatorIdFromService, expressionValues))
-                .subType(expressionValues.get(operation.getSubType()))
-                .extra(expressionValues.get(operation.getExtra()))
-                .codeVariable(getCodeVariable(method))
-                .action(expressionValues.get(action))
-                .fail(flag)
-                .createTime(new Date())
-                .build();
-
-        bizLogService.record(logRecord);
+        if (operation.getList() != null && !operation.getList().isEmpty()) {
+            for (String listItem : operation.getList()) {
+                LogRecord logRecord = LogRecord.builder()
+                        .tenant(tenantId)
+                        .type(expressionValues.get(operation.getType()))
+                        .bizNo(expressionValues.get(operation.getBizNo()))
+                        .operator(getRealOperatorId(operation, operatorIdFromService, expressionValues))
+                        .subType(expressionValues.get(operation.getSubType()))
+                        .extra(expressionValues.get(operation.getExtra()))
+                        .codeVariable(getCodeVariable(method))
+                        .action(expressionValues.get(action))
+                        .fail(flag)
+                        .createTime(new Date())
+                        .build();
+                bizLogService.record(logRecord);
+            }
+        } else {
+            LogRecord logRecord = LogRecord.builder()
+                    .tenant(tenantId)
+                    .type(expressionValues.get(operation.getType()))
+                    .bizNo(expressionValues.get(operation.getBizNo()))
+                    .operator(getRealOperatorId(operation, operatorIdFromService, expressionValues))
+                    .subType(expressionValues.get(operation.getSubType()))
+                    .extra(expressionValues.get(operation.getExtra()))
+                    .codeVariable(getCodeVariable(method))
+                    .action(expressionValues.get(action))
+                    .fail(flag)
+                    .createTime(new Date())
+                    .build();
+            bizLogService.record(logRecord);
+        }
     }
 
     private Map<CodeVariableType, Object> getCodeVariable(Method method) {

--- a/bizlog-sdk/src/main/java/com/mzt/logapi/starter/support/aop/LogRecordOperationSource.java
+++ b/bizlog-sdk/src/main/java/com/mzt/logapi/starter/support/aop/LogRecordOperationSource.java
@@ -115,6 +115,7 @@ public class LogRecordOperationSource {
                 .extra(recordAnnotation.extra())
                 .condition(recordAnnotation.condition())
                 .isSuccess(recordAnnotation.successCondition())
+                .list(recordAnnotation.list())
                 .build();
         validateLogRecordOperation(ae, recordOps);
         return recordOps;

--- a/bizlog-sdk/src/main/java/com/mzt/logapi/starter/support/parse/LogRecordValueParser.java
+++ b/bizlog-sdk/src/main/java/com/mzt/logapi/starter/support/parse/LogRecordValueParser.java
@@ -140,6 +140,44 @@ public class LogRecordValueParser implements BeanFactoryAware {
         return functionNameAndReturnValueMap;
     }
 
+    public List<Map<String, String>> processTemplateForList(Collection<String> templates, MethodExecuteResult methodExecuteResult,
+                                                            Map<String, String> beforeFunctionNameAndReturnMap, List<?> list) {
+        List<Map<String, String>> expressionValuesList = new ArrayList<>();
+        for (Object item : list) {
+            Map<String, String> expressionValues = new HashMap<>();
+            EvaluationContext evaluationContext = expressionEvaluator.createEvaluationContext(methodExecuteResult.getMethod(),
+                    methodExecuteResult.getArgs(), methodExecuteResult.getTargetClass(), methodExecuteResult.getResult(),
+                    methodExecuteResult.getErrorMsg(), beanFactory);
+            evaluationContext.setVariable("item", item);
+
+            for (String expressionTemplate : templates) {
+                if (expressionTemplate.contains("{")) {
+                    Matcher matcher = pattern.matcher(expressionTemplate);
+                    StringBuffer parsedStr = new StringBuffer();
+                    AnnotatedElementKey annotatedElementKey = new AnnotatedElementKey(methodExecuteResult.getMethod(), methodExecuteResult.getTargetClass());
+                    boolean sameDiff = false;
+                    while (matcher.find()) {
+                        String expression = matcher.group(2);
+                        String functionName = matcher.group(1);
+                        if (DiffParseFunction.diffFunctionName.equals(functionName)) {
+                            expression = getDiffFunctionValue(evaluationContext, annotatedElementKey, expression);
+                            sameDiff = Objects.equals("", expression);
+                        } else {
+                            Object value = expressionEvaluator.parseExpression(expression, annotatedElementKey, evaluationContext);
+                            expression = logFunctionParser.getFunctionReturnValue(beforeFunctionNameAndReturnMap, value, expression, functionName);
+                        }
+                        matcher.appendReplacement(parsedStr, Matcher.quoteReplacement(expression == null ? "" : expression));
+                    }
+                    matcher.appendTail(parsedStr);
+                    expressionValues.put(expressionTemplate, recordSameDiff(sameDiff, diffSameWhetherSaveLog) ? parsedStr.toString() : expressionTemplate);
+                } else {
+                    expressionValues.put(expressionTemplate, expressionTemplate);
+                }
+            }
+            expressionValuesList.add(expressionValues);
+        }
+        return expressionValuesList;
+    }
 
     @Override
     public void setBeanFactory(BeanFactory beanFactory) throws BeansException {


### PR DESCRIPTION
Add support for batch logging in `@LogRecord` annotation.

* Add `String list()` attribute to `@LogRecord` annotation in `LogRecord.java`.
* Add `List<String> list` attribute to `LogRecordOps` class in `LogRecordOps.java`.
* Parse `list` attribute in `parseLogRecordAnnotation` method in `LogRecordOperationSource.java`.
* Handle `list` attribute in `recordExecute` method in `LogRecordInterceptor.java`.
* Add `record(List<LogRecord> logRecords)` method in `DefaultLogRecordServiceImpl.java` to save a list of `LogRecord` objects.
* Add `processTemplateForList` method in `LogRecordValueParser.java` to parse list attribute and generate multiple log records.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mouzt/mzt-biz-log/pull/174?shareId=a51d9d24-2185-44e4-abe4-65540da0eb9a).