### PR TITLE
fix(diff): 修复 对于不同类型对象校验失败

### DIFF
--- a/bizlog-sdk/src/main/java/com/mzt/logapi/service/impl/DiffParseFunction.java
+++ b/bizlog-sdk/src/main/java/com/mzt/logapi/service/impl/DiffParseFunction.java
@@ -48,8 +48,8 @@ public class DiffParseFunction {
                 throw new RuntimeException(e);
             }
         }
-        if (!Objects.equals(AopUtils.getTargetClass(source.getClass()), AopUtils.getTargetClass(target.getClass()))) {
-            log.error("diff的两个对象类型不同, source.class={}, target.class={}", source.getClass().toString(), target.getClass().toString());
+        if (!Objects.equals(AopUtils.getTargetClass(source), AopUtils.getTargetClass(target))) {
+            log.error("diff的两个对象类型不同, source={}, target={}", source, target);
             return "";
         }
         ObjectDifferBuilder objectDifferBuilder = ObjectDifferBuilder.startBuilding();


### PR DESCRIPTION
Objects.equals(AopUtils.getTargetClass(source.getClass()), AopUtils.getTargetClass(target.getClass()))
 // 等价于：
Objects.equals(Class.class, Class.class)
// 所以结果是 true